### PR TITLE
Change call to animate to pass the function

### DIFF
--- a/assignments/game-of-life/code.js
+++ b/assignments/game-of-life/code.js
@@ -119,4 +119,4 @@ const gameOfLife = () => {
   gameOfLife2()
 }
 
-animate(gameOfLife())
+animate(gameOfLife)


### PR DESCRIPTION
`animate` expects the function that it is supposed to call. The way you had it it, you were calling `gameOfLife` and passing the value it returned to `animate` and since `gameOfLife` doesn't have an explicit `return` it returns `undefined` so then in `animate` the variable that holds the argument happens to be called `drawFrame` led to the error about `drawFrame` being undefined.

I haven't looked at the rest of the code to make sure this will actually work but this change is at least part of what needs to happen.

BTW, we're getting into somewhat advanced Github usage here. I'm making a Pull Request against your branch. You can accept the pull request by hitting the green merge button which will apply my proposed change to your branch. You can then reload in the web browser and you should see the new version of the code with my change.